### PR TITLE
Add e.preventDefault() for body's pointerdown event to prevent context menu from popping up

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
     };
 
     document.body.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
       const center = { x: e.pageX, y: e.pageY };
       incrementClickCount();
       makeBurst(center);


### PR DESCRIPTION
Simply preventing the annoying context menu vastly improves touching grass user experience.