### PR TITLE
fix: disable double-tap zoom on iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>touch grass</title>
   <meta name="description" content="touch grass">
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
@@ -13,6 +13,10 @@
 
     :root {
       --background: url(assets/grass.png);
+    }
+
+    * {
+      touch-action: manipulation;
     }
 
     body {
@@ -225,6 +229,15 @@
         styleSheet.length
       );
     };
+
+    let lastTap = 0;
+    document.addEventListener("touchend", (e) => {
+      const now = Date.now();
+      if (now - lastTap < 500 && now - lastTap > 0) {
+        e.preventDefault();
+      }
+      lastTap = now;
+    }, { passive: false });
 
     document.body.addEventListener("pointerdown", (e) => {
       e.preventDefault();


### PR DESCRIPTION
On iOS Safari, double-tapping the screen triggers a zoom-in behavior which interferes with the clicking mechanic on touchgrass. Added `touch-action: manipulation` to the body style, which disables double-tap zoom while keeping all other touch behavior intact.

You can test the fix here:  
[touchgrasss.pages.dev](https://touchgrasss.pages.dev)

Before / after:  
[imgur.com/a/x6rnpeu](https://imgur.com/a/x6rnpeu)